### PR TITLE
Update site copy for ongoing defense testimony

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Karen Read Trial Evidence Tracker
 
-This project is a comprehensive, open-source initiative to document and compare the evidence and arguments presented to the jury in both the first Karen Read trial (2024) and the retrial (2025). Updated through June 1, 2025, compiled by Claude Code with the latest trial developments and synthesizes all facts known to the jury in both trials.
+This project is a comprehensive, open-source initiative to document and compare the evidence and arguments presented to the jury in both the first Karen Read trial (2024) and the retrial (2025). Updated through June 8, 2025, compiled by Claude Code with the latest trial developments and synthesizes all facts known to the jury in both trials.
 
 ## Project Status (June 2025)
 
-**Current Trial Status:** The retrial prosecution rested their case on May 30, 2025, after calling 38 witnesses over 23 days of testimony. The defense began presenting their case with crash reconstruction expert Matthew DiSogra.
+**Current Trial Status:** The retrial prosecution rested their case on May 30, 2025, after calling 38 witnesses over 23 days of testimony. The defense is now presenting its case, with testimony ongoing as of June 8, 2025.
 
 **Site Features:**
 - **Evidence Comparison Table:** 15 key facts comparing prosecution vs defense arguments across both trials
@@ -109,7 +109,7 @@ This section tracks dead or outdated reference links that have been replaced or 
 **Built With:** HTML5, CSS3, Claude Code analysis
 **Optimized For:** Mobile-first responsive design
 **Sources:** 25+ verified news outlets and court coverage
-**Updated:** June 1, 2025 (through prosecution case completion)
+**Updated:** June 8, 2025 (defense testimony ongoing; further details pending verification)
 
 ## Contributing
 
@@ -123,4 +123,4 @@ This is an open-source project. Contributions are welcome for:
 
 **Not affiliated with the court or any party. For educational and informational use only.**
 
-_Last updated: June 1, 2025 - Prosecution case complete, defense case beginning_
+_Last updated: June 8, 2025 - Defense testimony ongoing_

--- a/index.html
+++ b/index.html
@@ -12,8 +12,9 @@
   <h2 style="font-size:1.3em; color:#4e73df; margin:0.5em 0 1.5em 0; font-weight:500;">Comprehensive Evidence Analysis & Trial Timeline</h2>
   
   <div style="background:linear-gradient(135deg,#f8fafc 0%,#e3eefe 100%); padding:1.5em; border-radius:12px; margin:1em 0; box-shadow:0 2px 8px rgba(80,120,200,0.08);">
-    <p style="margin:0 0 0.8em 0; font-size:1.05em; color:#2d3748;"><strong>Latest Update:</strong> June 1, 2025 – Compiled by Claude Code</p>
-    <p style="margin:0 0 0.8em 0; color:#4a5568;"><strong>Trial Status:</strong> Prosecution rested May 30, 2025 (38 witnesses, 23 days of testimony)</p>
+    <p style="margin:0 0 0.8em 0; font-size:1.05em; color:#2d3748;"><strong>Latest Update:</strong> June 8, 2025 – Compiled by Claude Code</p>
+    <p style="margin:0 0 0.8em 0; color:#4a5568;"><strong>Trial Status:</strong> Prosecution rested May 30, 2025 (38 witnesses, 23 days of testimony); defense case ongoing</p>
+    <p style="margin:0 0 0.8em 0; color:#718096; font-size:0.95em;">Coverage of defense testimony after May 30 will be added once additional verified sources are available.</p>
     <p style="margin:0; color:#4a5568; font-style:italic;">Providing unbiased comparison of prosecution and defense arguments across both trials</p>
   </div>
 </header>

--- a/links.html
+++ b/links.html
@@ -9,7 +9,7 @@
 <body>
 <header>
   <h1>Source Links & References</h1>
-  <p>Key sources, evidence galleries, and comprehensive trial coverage referenced in the evidence tables. Updated June 1, 2025.</p>
+  <p>Key sources, evidence galleries, and comprehensive trial coverage referenced in the evidence tables. Updated June 8, 2025.</p>
 </header>
 <main>
   <p><a href="index.html" class="llm-link">&larr; Back to Table Index</a></p>
@@ -52,7 +52,7 @@
   <section>
     <h2>About This Project</h2>
     <p>This site is a public, open-source project updated by Claude Code to track and compare evidence presented to the jury in both the first and current Karen Read trials. The comprehensive analysis includes a daily trial timeline correlated with evidence facts.</p>
-    <p><strong>Last Updated:</strong> June 1, 2025 with prosecution case completion and defense beginning.</p>
+    <p><strong>Last Updated:</strong> June 8, 2025 &ndash; defense testimony ongoing, additional updates forthcoming.</p>
   </section>
 </main>
 <footer>


### PR DESCRIPTION
## Summary
- update update dates in README and pages to June 8, 2025
- clarify in index and links pages that defense testimony is ongoing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847036ff8bc833398f412d80f83bc65