### PR TITLE
Add sliders to adjust evidence weights in Bayesian demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,12 +423,20 @@
 
     <section class="content-box">
       <h2>4. What Happens When We Add It All Up?</h2>
-      <p>Let's say the evidence is:</p>
-      <ul>
-        <li>1× supportive of H1</li>
-        <li>6× supportive of H2</li>
-        <li>3× supportive of H3</li>
-      </ul>
+      <p>The weight of the evidence reflects how many clues point toward each hypothesis. Adjust the sliders to change these weights:</p>
+      <form id="weightsForm" style="margin: 20px 0;">
+        <label for="weight-h1">Support for H1</label><br>
+        <input type="range" id="weight-h1" name="weight-h1" min="0" max="10" step="0.1" value="1">
+        <span id="weight-h1-val" style="margin-left: 10px;">1</span>×<br><br>
+
+        <label for="weight-h2">Support for H2</label><br>
+        <input type="range" id="weight-h2" name="weight-h2" min="0" max="10" step="0.1" value="6">
+        <span id="weight-h2-val" style="margin-left: 10px;">6</span>×<br><br>
+
+        <label for="weight-h3">Support for H3</label><br>
+        <input type="range" id="weight-h3" name="weight-h3" min="0" max="10" step="0.1" value="3">
+        <span id="weight-h3-val" style="margin-left: 10px;">3</span>×
+      </form>
       
       <p>We update our beliefs:</p>
       <div class="probability-display">
@@ -514,7 +522,8 @@
   <script>
     // Interactive Priors Slider Chart
     const sliders = ['h1', 'h2', 'h3'];
-    const weights = { h1: 1, h2: 6, h3: 3 }; // Fixed evidence weights
+    const weightSliders = ['weight-h1', 'weight-h2', 'weight-h3'];
+    const weights = { h1: 1, h2: 6, h3: 3 };
     const ctx = document.getElementById('posteriorChart').getContext('2d');
 
     let chart = new Chart(ctx, {
@@ -561,7 +570,18 @@
       }
     });
 
+    function updateWeights() {
+      weights.h1 = parseFloat(document.getElementById('weight-h1').value);
+      weights.h2 = parseFloat(document.getElementById('weight-h2').value);
+      weights.h3 = parseFloat(document.getElementById('weight-h3').value);
+
+      document.getElementById('weight-h1-val').innerText = weights.h1;
+      document.getElementById('weight-h2-val').innerText = weights.h2;
+      document.getElementById('weight-h3-val').innerText = weights.h3;
+    }
+
     function updateChart() {
+      updateWeights();
       let h1 = parseInt(document.getElementById('h1').value);
       let h2 = parseInt(document.getElementById('h2').value);
       let h3 = parseInt(document.getElementById('h3').value);
@@ -609,7 +629,7 @@
     }
 
     // Add event listeners to sliders
-    sliders.forEach(id => {
+    [...sliders, ...weightSliders].forEach(id => {
       document.getElementById(id).addEventListener('input', updateChart);
     });
 


### PR DESCRIPTION
## Summary
- make evidence multipliers adjustable with new sliders
- compute weights dynamically when the chart updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853eea31df48333abae988ad2ebd00d